### PR TITLE
Clarify Library Version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ platform :ios, '9.0'
 target 'TwitterShareSample' do
   use_frameworks!
 
-  pod 'TwitterKit'
+  pod 'TwitterKit', '3.2.2'
 end


### PR DESCRIPTION
Overview
The content of this project has become a thing of the past due to specification change of TwitterKit

Details
This project works because CocoaPods is used and TwitterKit version is set by .lock file,
When newly developing without specifying the version, the latest TwitterKit (3.3.0) is introduced and it will not work with this sample.
This time, specify the version corresponding to this project in the Podfile.